### PR TITLE
Add java compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Compatibility with Java
+
+### Changed
+- BREAKING: Kotlin API changed
+
 ## 0.1.0 - 2021-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ An example demonstrating how to use world tides lib to fetch tides extremes from
 
 ## Limitations
 
-- Currently this project is incompatible with Java due to the use of Kotlin [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/) type.
-The plan is to introduce a Java-friendly API in future.
 - This lib uses Retrofit and OkHttp and at the moment it's not possible to pass in you existing OkHttp or other client
 to be used by retrofit. The plan is to allow the user of the lib to pass in the client to avoid creating multiple
 clients in your app.

--- a/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/TidesCallback.kt
+++ b/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/TidesCallback.kt
@@ -3,5 +3,6 @@ package com.oleksandrkruk.worldtides
 import com.oleksandrkruk.worldtides.extremes.models.TideExtremes
 
 interface TidesCallback {
-    fun result(result: Result<TideExtremes>)
+    fun result(tides: TideExtremes)
+    fun error(error: Error)
 }

--- a/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/WorldTides.kt
+++ b/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/WorldTides.kt
@@ -1,6 +1,7 @@
 package com.oleksandrkruk.worldtides
 
 import com.oleksandrkruk.worldtides.extremes.WorldTidesRepository
+import com.oleksandrkruk.worldtides.extremes.models.TideExtremes
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -45,8 +46,29 @@ class WorldTides private constructor(
      * otherwise it will provide an error.
      *
      */
-    fun getTideExtremes(date: Date, days: Int, lat: String, lon: String, callback: TidesCallback) {
+    fun getTideExtremes(date: Date, days: Int, lat: String, lon: String, callback: (Result<TideExtremes>) -> Unit) {
         val dateStr = inputDateFormat.format(date)
         tidesRepository.extremes(dateStr, days, lat, lon, apiKey, callback)
+    }
+
+    /**
+     * Returns only the extremes of the tides (Highs and Lows) between [date] and the number of [days] in future.
+     * **This method exists for Java interoperability only.**
+     *
+     * @param [date] should be the starting date from which the tide extremes prediction are requested.
+     * @param [days] should be the number of days for which tide extremes are requested. This number will add
+     * to the [date] and will form a time range. E.g.: If the given [date] is 2020-12-01 and [days]
+     * is 3 it means that the user will receive all tides between 2020-12-01 and 2020-12-03.
+     * @param [lat] is the latitude of the location for which the tides are requested.
+     * @param [lon] is the longitude of the location for which the tides are requested.
+     * @param [callback] is the callback that will return either tide or an error.
+     *
+     */
+    fun getTideExtremes(date: Date, days: Int, lat: String, lon: String, callback: TidesCallback) {
+        val dateStr = inputDateFormat.format(date)
+        tidesRepository.extremes(dateStr, days, lat, lon, apiKey) { result ->
+            result.onFailure { callback.error(Error(it)) }
+            result.onSuccess { callback.result(it) }
+        }
     }
 }

--- a/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/extremes/WorldTidesRepository.kt
+++ b/worldtides/src/main/kotlin/com/oleksandrkruk/worldtides/extremes/WorldTidesRepository.kt
@@ -1,6 +1,5 @@
 package com.oleksandrkruk.worldtides.extremes
 
-import com.oleksandrkruk.worldtides.TidesCallback
 import com.oleksandrkruk.worldtides.extremes.data.TideExtremesResponse
 import com.oleksandrkruk.worldtides.extremes.models.Extreme
 import com.oleksandrkruk.worldtides.extremes.models.TideExtremes
@@ -15,10 +14,10 @@ internal class WorldTidesRepository(
     private val dateFormat: SimpleDateFormat
 ) {
 
-    fun extremes(date: String, days: Int, lat: String, lon: String, apiKey: String, callback: TidesCallback) {
+    fun extremes(date: String, days: Int, lat: String, lon: String, apiKey: String, callback: (Result<TideExtremes>) -> Unit) {
         tidesService.extremes(date, days, lat, lon, apiKey).enqueue(object : Callback<TideExtremesResponse> {
             override fun onFailure(call: Call<TideExtremesResponse>, t: Throwable) {
-                callback.result(Result.failure(t))
+                callback(Result.failure(t))
             }
 
             override fun onResponse(call: Call<TideExtremesResponse>, response: Response<TideExtremesResponse>) {
@@ -28,12 +27,12 @@ internal class WorldTidesRepository(
                             Extreme(dateFormat.parse(extreme.date), extreme.height, TideType.valueOf(extreme.type))
                         }
                         val tideExtremes = TideExtremes(extremes)
-                        callback.result(Result.success(tideExtremes))
+                        callback(Result.success(tideExtremes))
                     } ?: run {
-                        callback.result(Result.failure(Error("Response is successful but failed getting body")))
+                        callback(Result.failure(Error("Response is successful but failed getting body")))
                     }
                 } else {
-                    callback.result(Result.failure(Error("Response body is null or response is not successful")))
+                    callback(Result.failure(Error("Response body is null or response is not successful")))
                 }
             }
         })

--- a/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/WorldTidesJavaApiTest.kt
+++ b/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/WorldTidesJavaApiTest.kt
@@ -1,0 +1,17 @@
+package com.oleksandrkruk.worldtides;
+
+import com.oleksandrkruk.worldtides.extremes.models.TideExtremes;
+import org.junit.jupiter.api.Test;
+import java.util.*
+
+class WorldTidesJavaApiTest {
+
+    @Test
+    fun providesJavaCompatibleApiForExtremes() {
+        val wt = WorldTides.Builder().build("bar")
+        wt.getTideExtremes(Date(), 5, "lat", "lon", object : TidesCallback {
+            override fun result(tides: TideExtremes) {}
+            override fun error(error: Error) {}
+        })
+    }
+}

--- a/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/WorldTidesTest.kt
+++ b/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/WorldTidesTest.kt
@@ -3,7 +3,6 @@ package com.oleksandrkruk.worldtides
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import java.util.*
 
 class WorldTidesTest {
@@ -14,12 +13,12 @@ class WorldTidesTest {
         Assertions.assertNotNull(worldTides)
     }
 
+    // TODO this is not an optimal test. Need to improve it by testing the invocation of the dependencies.
     @Test
     @DisplayName("exposes method to get tide extremes")
-    fun invokesRepository() {
+    fun providesKotlinIdiomaticApiForExtremes() {
         val builder = WorldTides.Builder()
         val worldTides = builder.build("someKey")
-        val callbackMock = Mockito.mock(TidesCallback::class.java)
-        worldTides.getTideExtremes(Date(), 5, "someLat", "someLon", callbackMock)
+        worldTides.getTideExtremes(Date(), 5, "someLat", "someLon") {}
     }
 }

--- a/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/extremes/WorldTidesRepositoryTest.kt
+++ b/worldtides/src/test/kotlin/com/oleksandrkruk/worldtides/extremes/WorldTidesRepositoryTest.kt
@@ -1,9 +1,7 @@
 package com.oleksandrkruk.worldtides.extremes
 
-import com.oleksandrkruk.worldtides.TidesCallback
 import com.oleksandrkruk.worldtides.extremes.data.ExtremeResponse
 import com.oleksandrkruk.worldtides.extremes.data.TideExtremesResponse
-import com.oleksandrkruk.worldtides.extremes.models.TideExtremes
 import com.oleksandrkruk.worldtides.extremes.models.TideType
 import okhttp3.MediaType
 import okhttp3.ResponseBody
@@ -54,30 +52,25 @@ class WorldTidesRepositoryTest {
 
         tidesResponse = TideExtremesResponse(200, null, listOf(buildExtremeData()))
 
-        tidesRepository.extremes("" ,1, "", "", "", object : TidesCallback {
-
-            override fun result(result: Result<TideExtremes>) {
-                assertTrue(result.isSuccess)
-                result.onSuccess { tides ->
-                    assertEquals(1, tides.extremes.size)
-                    assertEquals(today.toString(), tides.extremes.first().date.toString())
-                    assertEquals(0.45f, tides.extremes.first().height)
-                    assertEquals(TideType.High, tides.extremes.first().type)
-                }
-
-                result.onFailure {
-                    fail("should never invoke failure on successful response")
-                }
+        tidesRepository.extremes("" ,1, "", "", "") { result ->
+            assertTrue(result.isSuccess)
+            result.onSuccess { tides ->
+                assertEquals(1, tides.extremes.size)
+                assertEquals(today.toString(), tides.extremes.first().date.toString())
+                assertEquals(0.45f, tides.extremes.first().height)
+                assertEquals(TideType.High, tides.extremes.first().type)
             }
-        })
+
+            result.onFailure {
+                fail("should never invoke failure on successful response")
+            }
+        }
     }
 
     @Test
     fun bubblesUpTheErrorOnFailure() {
         withFailedResponse()
-        tidesRepository.extremes("" ,1, "", "", "", object : TidesCallback {
-
-            override fun result(result: Result<TideExtremes>) {
+        tidesRepository.extremes("" ,1, "", "", "") { result ->
                 assertTrue(result.isFailure)
                 result.onSuccess { _ ->
                     fail("should never invoke success on failed response")
@@ -86,8 +79,7 @@ class WorldTidesRepositoryTest {
                 result.onFailure {
                     assertEquals(Error::class, it::class)
                 }
-            }
-        })
+        }
     }
 
     private fun buildExtremeData(


### PR DESCRIPTION
Currently because of usage of Result type, the API is only usable from Kotlin. This PR adds another method without Result type so that this client can be used from Java code.